### PR TITLE
bugfix: check result use namespace

### DIFF
--- a/.github/workflows/upload_component.yml
+++ b/.github/workflows/upload_component.yml
@@ -1,0 +1,19 @@
+name: Push components to Espressif Component Service
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  upload_components:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+        with:
+          submodules: 'recursive'
+      - name: Upload components to component service
+        uses: espressif/upload-components-ci-action@v1
+        with:
+          name: "ESP32_IO_Expander"
+          namespace: "lzw655"
+          api_token: ${{secrets.IDF_COMPONENT_API_TOKEN}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,13 @@
 * Add `getHandle()` API
 * Update CI for building `test_apps`
 * Update CI for `pre-commit`
+
+## v1.0.2 - 2023-08-10
+
+### Fixed:
+
+* Use namespace for `CheckResult`
+
+### Enhancements:
+
+* Upload into Espressif Registry

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ The following tables show the supported SDK versions for ESP32_IO_Expander at di
 
 | **ESP32_IO_Expander** | **Arduino-ESP32** |   **ESP-IDF**    |
 | :-------------------: | :---------------: | :--------------: |
-|        v1.0.0         | v2.0.9 and later  |      v4.4.5      |
+|        v1.0.0         | v2.0.9 and later  | v4.4.5 and later |
 |        v1.0.1         | v2.0.9 and later  | v4.4.5 and later |
+|        v1.0.2         | v2.0.9 and later  | v4.4.5 and later |
 
 ## Supported Drivers
 

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,5 @@
+version: "1.0.2"
+description: ESP32 IO Expander Driver which encapsulates various components using C++
+url: https://github.com/Lzw655/ESP32_IOExpander
+dependencies:
+  idf: ">=4.4.5"

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=ESP32 IO Expander Driver
-version=1.0.1
+version=1.0.2
 author=Lzw655 <liuzhongwei@espressif.com>
 maintainer=lzw655 <liuzhongwei@espressif.com>
 sentence=ESP32_IOExpander is a library for various IO expander chips driven by ESP32
-paragraph=Currently support TC95xx (8bit), TCA95xx (16bit), HT8574
+paragraph=Currently support TCA95xx (8bit), TCA95xx (16bit), HT8574
 category=Other
 architectures=esp32
 url=https://github.com/Lzw655/ESP32_IOExpander

--- a/src/chip/HT8574.cpp
+++ b/src/chip/HT8574.cpp
@@ -66,7 +66,7 @@ static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *v
 static esp_err_t reset(esp_io_expander_t *handle);
 static esp_err_t del(esp_io_expander_t *handle);
 
-esp_err_t esp_io_expander_new_i2c_ht8574(i2c_port_t i2c_num, uint32_t i2c_address, esp_io_expander_handle_t *handle)
+static esp_err_t esp_io_expander_new_i2c_ht8574(i2c_port_t i2c_num, uint32_t i2c_address, esp_io_expander_handle_t *handle)
 {
     ESP_RETURN_ON_FALSE(i2c_num < I2C_NUM_MAX, ESP_ERR_INVALID_ARG, TAG, "Invalid i2c num");
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");

--- a/src/chip/TCA95xx_16bit.cpp
+++ b/src/chip/TCA95xx_16bit.cpp
@@ -71,7 +71,7 @@ static esp_err_t read_direction_reg(esp_io_expander_handle_t handle, uint32_t *v
 static esp_err_t reset(esp_io_expander_t *handle);
 static esp_err_t del(esp_io_expander_t *handle);
 
-esp_err_t esp_io_expander_new_i2c_tca95xx_16bit(i2c_port_t i2c_num, uint32_t i2c_address, esp_io_expander_handle_t *handle)
+static esp_err_t esp_io_expander_new_i2c_tca95xx_16bit(i2c_port_t i2c_num, uint32_t i2c_address, esp_io_expander_handle_t *handle)
 {
     ESP_RETURN_ON_FALSE(i2c_num < I2C_NUM_MAX, ESP_ERR_INVALID_ARG, TAG, "Invalid i2c num");
     ESP_RETURN_ON_FALSE(handle, ESP_ERR_INVALID_ARG, TAG, "Invalid handle");

--- a/src/private/CheckResult.cpp
+++ b/src/private/CheckResult.cpp
@@ -6,6 +6,8 @@
 
 #include <stddef.h>
 
+namespace esp_io_expander {
+
 const char *path_to_file_name(const char *path)
 {
     size_t i = 0;
@@ -19,4 +21,6 @@ const char *path_to_file_name(const char *path)
         p++;
     }
     return path + pos;
+}
+
 }

--- a/src/private/CheckResult.h
+++ b/src/private/CheckResult.h
@@ -14,11 +14,7 @@
 #include "esp_check.h"
 #include "esp_log.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#define ERROR_CHECK_LOG_FORMAT(format)      "[%s:%u] %s(): " format, path_to_file_name(__FILE__), __LINE__, __FUNCTION__
+#define ERROR_CHECK_LOG_FORMAT(format)      "[%s:%u] %s(): " format, esp_io_expander::path_to_file_name(__FILE__), __LINE__, __FUNCTION__
 #define ERROR_CHECK_LOGE(tag, format, ...)  ESP_LOGE(tag, ERROR_CHECK_LOG_FORMAT(format), ##__VA_ARGS__)
 
 #define CHECK_ERROR_RETURN(x)  do {         \
@@ -65,10 +61,8 @@ extern "C" {
         }                                   \
     } while(0)
 
+namespace esp_io_expander {
 const char *path_to_file_name(const char *path);
-
-#ifdef __cplusplus
 }
-#endif
 
 #endif


### PR DESCRIPTION
## v1.0.2 - 2023-08-10

### Fixed:

* Use namespace for `CheckResult`

### Enhancements:

* Upload into Espressif Registry
