### PR TITLE
bugfix: change library name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,9 @@
 ### Enhancements:
 
 * Upload into Espressif Registry
+
+## v1.1.0 - 2023-08-14
+
+### Fixed:
+
+* Change library name to `ESP32_IO_Expander`

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ expander->multiDigitalWrite(IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1, HIGH)
 expander->multiDigitalWrite(IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1, LOW);
 expander->multiPinMode(IO_EXPANDER_PIN_NUM_0 | IO_EXPANDER_PIN_NUM_1, INPUT);
 uint32_t level = expander->multiDigitalRead(IO_EXPANDER_PIN_NUM_2 | IO_EXPANDER_PIN_NUM_3);
+
+// Release the ESP_IOExpander object
+delete expander;
 ```
 
 ## Arduino Example
@@ -40,17 +43,15 @@ uint32_t level = expander->multiDigitalRead(IO_EXPANDER_PIN_NUM_2 | IO_EXPANDER_
 
 The following tables show the supported SDK versions for ESP32_IO_Expander at different versions.
 
-| **ESP32_IO_Expander** | **Arduino-ESP32** |   **ESP-IDF**    |
-| :-------------------: | :---------------: | :--------------: |
-|        v1.0.0         | v2.0.9 and later  | v4.4.5 and later |
-|        v1.0.1         | v2.0.9 and later  | v4.4.5 and later |
-|        v1.0.2         | v2.0.9 and later  | v4.4.5 and later |
+| **ESP32_IO_Expander** | **Arduino-ESP32** | **ESP-IDF** |
+| :-------------------: | :---------------: | :---------: |
+|        v1.x.x         |     >= v2.0.9     |  >= v4.4.5  |
 
 ## Supported Drivers
 
 |   **Driver**    |                                         **Version**                                          |
 | --------------- | -------------------------------------------------------------------------------------------- |
-| Base Component  | [1.0.1](https://components.espressif.com/components/espressif/esp_io_expander)               |
+| esp_io_expander | [1.0.1](https://components.espressif.com/components/espressif/esp_io_expander)               |
 | TCA95xx (8bit)  | [1.0.1](https://components.espressif.com/components/espressif/esp_io_expander_tca9554)       |
 | TCA95xx (16bit) | [1.0.0](https://components.espressif.com/components/espressif/esp_io_expander_tca95xx_16bit) |
 | HT8574          | [1.0.0](https://components.espressif.com/components/espressif/esp_io_expander_ht8574)        |

--- a/check_copyright_config.yaml
+++ b/check_copyright_config.yaml
@@ -28,7 +28,6 @@ DEFAULT:
 # You can create your own rules for files or group of files
 examples_and_unit_tests:
   include:
-   - 'src/'
    - 'test_apps/'
   allowed_licenses:
   - Apache-2.0

--- a/library.properties
+++ b/library.properties
@@ -1,10 +1,10 @@
-name=ESP32 IO Expander Driver
-version=1.0.2
+name=ESP32_IO_Expander
+version=1.1.0
 author=Lzw655 <liuzhongwei@espressif.com>
 maintainer=lzw655 <liuzhongwei@espressif.com>
-sentence=ESP32_IOExpander is a library for various IO expander chips driven by ESP32
+sentence=ESP32_IO_Expander is a library for various IO expander chips driven by ESP32
 paragraph=Currently support TCA95xx (8bit), TCA95xx (16bit), HT8574
 category=Other
 architectures=esp32
-url=https://github.com/Lzw655/ESP32_IOExpander
+url=https://github.com/Lzw655/ESP32_IO_Expander
 includes=ESP_IOExpander_Library.h


### PR DESCRIPTION
## v1.1.0 - 2023-08-14

### Fixed:

* Change library name to `ESP32_IO_Expander`
